### PR TITLE
Adds better support for Berry Bushes

### DIFF
--- a/src/main/java/com/ewyboy/quickharvest/api/HarvestManager.java
+++ b/src/main/java/com/ewyboy/quickharvest/api/HarvestManager.java
@@ -72,6 +72,7 @@ public class HarvestManager {
         register(new DefaultHarvester(() -> Items.BEETROOT_SEEDS, () -> Blocks.BEETROOTS.getDefaultState(), BeetrootBlock.BEETROOT_AGE), () -> Blocks.BEETROOTS);
         register(new DefaultHarvester(() -> Items.NETHER_WART, () -> Blocks.NETHER_WART.getDefaultState(), NetherWartBlock.AGE), () -> Blocks.NETHER_WART);
         register(new DefaultHarvester(() -> Items.COCOA_BEANS, () -> Blocks.COCOA.getDefaultState(), CocoaBlock.AGE), () -> Blocks.COCOA);
+        register(new DefaultHarvester(() -> Items.SWEET_BERRIES, () -> Blocks.SWEET_BERRY_BUSH.getDefaultState().with(SweetBerryBushBlock.AGE, 1), SweetBerryBushBlock.AGE, 2), () -> Blocks.SWEET_BERRY_BUSH);
         register(new StemPlantHarvester(), () -> Blocks.ATTACHED_MELON_STEM, () -> Blocks.MELON);
         register(new StemPlantHarvester(), () -> Blocks.ATTACHED_PUMPKIN_STEM, () -> Blocks.PUMPKIN);
         register(new TallPlantHarvester(), () -> Blocks.SUGAR_CANE, () -> Blocks.CACTUS);

--- a/src/main/java/com/ewyboy/quickharvest/harvester/DefaultHarvester.java
+++ b/src/main/java/com/ewyboy/quickharvest/harvester/DefaultHarvester.java
@@ -19,13 +19,17 @@ import java.util.function.Supplier;
 
 public class DefaultHarvester extends HarvesterImpl {
 
-    private final int maxAge;
+    private final int harvestAge;
     private final IntegerProperty ageProperty;
 
-    public DefaultHarvester(Supplier<Item> replantItem, Supplier<BlockState> replantState, IntegerProperty ageProperty) {
+    public DefaultHarvester(Supplier<Item> replantItem, Supplier<BlockState> replantState, IntegerProperty ageProperty, int minHarvestAge) {
         super(QuickHarvest.HOE_TAG, () -> new ItemStack(replantItem.get()), replantState);
         this.ageProperty = ageProperty;
-        this.maxAge = ageProperty.getAllowedValues().stream().mapToInt(Integer::intValue).max().getAsInt();
+        this.harvestAge = minHarvestAge;
+    }
+
+    public DefaultHarvester(Supplier<Item> replantItem, Supplier<BlockState> replantState, IntegerProperty ageProperty) {
+        this(replantItem, replantState, ageProperty, ageProperty.getAllowedValues().stream().mapToInt(Integer::intValue).max().getAsInt());
     }
 
     @Override
@@ -35,7 +39,7 @@ public class DefaultHarvester extends HarvesterImpl {
 
     @Override
     public boolean canHarvest(ServerPlayerEntity player, Hand hand, ServerWorld world, BlockPos pos, BlockState state) {
-        return super.canHarvest(player, hand, world, pos, state) && state.func_235901_b_(this.ageProperty) && state.get(this.ageProperty) == this.maxAge;
+        return super.canHarvest(player, hand, world, pos, state) && state.func_235901_b_(this.ageProperty) && state.get(this.ageProperty) >= this.harvestAge;
     }
 
     @Override


### PR DESCRIPTION
The problem: In vanilla berry bushes would drop their items on the ground, something which this mod avoids by placing the items directly in the player's inventory.

The solution: Extend the DefaultHarvester to accomadate plants that can be harvested before their max age, and add berry bushes to the harvesters using a DefaultHarvester.

Signed-off-by: Luke Gilfoyle (1700189) <l.gilfoyle@wlv.ac.uk>